### PR TITLE
Excluir facturas

### DIFF
--- a/Controller/Modelo347.php
+++ b/Controller/Modelo347.php
@@ -359,11 +359,10 @@ class Modelo347 extends Controller
     {
         // Esto se puede simplificar con EXTRACT(MONTH FROM fecha) que es general para Mysql y Postgresql.
         // Se puede unificar con cliente en una sola función. (tabla y nombre campo)
+        $where = " WHERE codejercicio = " . $this->dataBase->var2str($this->codejercicio) . " AND COALESCE(excluir347, false) = false";
         $sql = strtolower(FS_DB_TYPE) == 'postgresql' ?
-            "SELECT codcliente, cifnif, to_char(fecha,'FMMM') as mes, sum(total) as total FROM facturascli"
-            . " WHERE codejercicio = " . $this->dataBase->var2str($this->codejercicio) :
-            "SELECT codcliente, cifnif, DATE_FORMAT(fecha, '%m') as mes, sum(total) as total FROM facturascli"
-            . " WHERE codejercicio = " . $this->dataBase->var2str($this->codejercicio);
+            "SELECT codcliente, cifnif, to_char(fecha,'FMMM') as mes, sum(total) as total FROM facturascli" . $where :
+            "SELECT codcliente, cifnif, DATE_FORMAT(fecha, '%m') as mes, sum(total) as total FROM facturascli" . $where;
 
         if ($this->excludeIrpf) {
             $sql .= " AND irpf = 0";
@@ -473,11 +472,10 @@ class Modelo347 extends Controller
     {
         // Esto se puede simplificar con EXTRACT(MONTH FROM fecha) que es general para Mysql y Postgresql.
         // Se puede unificar con cliente en una sola función. (tabla y nombre campo)
+        $where = " WHERE codejercicio = " . $this->dataBase->var2str($this->codejercicio) . " AND COALESCE(excluir347, false) = false";
         $sql = strtolower(FS_DB_TYPE) == 'postgresql' ?
-            "SELECT codproveedor, cifnif, to_char(fecha,'FMMM') as mes, sum(total) as total FROM facturasprov"
-            . " WHERE codejercicio = " . $this->dataBase->var2str($this->codejercicio) :
-            "SELECT codproveedor, cifnif, DATE_FORMAT(fecha, '%m') as mes, sum(total) as total FROM facturasprov"
-            . " WHERE codejercicio = " . $this->dataBase->var2str($this->codejercicio);
+            "SELECT codproveedor, cifnif, to_char(fecha,'FMMM') as mes, sum(total) as total FROM facturasprov" . $where :
+            "SELECT codproveedor, cifnif, DATE_FORMAT(fecha, '%m') as mes, sum(total) as total FROM facturasprov" . $where;
 
         if ($this->excludeIrpf) {
             $sql .= " AND irpf = 0";

--- a/Extension/Table/facturascli.xml
+++ b/Extension/Table/facturascli.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   This file is part of Modelo347 plugin for FacturaScripts
+   Copyright (C) 2020-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+    Document   : facturascli.xml
+    Author     : Jose Antonio Cuello    <yopli2000@gmail.com>
+    Description:
+        Add fields to basic structure of facturascli table.
+        - excluir347: indicates if the document should be excluded from 347.
+-->
+<table>
+    <column>
+        <name>excluir347</name>
+        <type>boolean</type>
+        <default>false</default>
+    </column>
+</table>

--- a/Extension/Table/facturasprov.xml
+++ b/Extension/Table/facturasprov.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   This file is part of Modelo347 plugin for FacturaScripts
+   Copyright (C) 2020-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+    Document   : facturasprov.xml
+    Author     : Jose Antonio Cuello    <yopli2000@gmail.com>
+    Description:
+        Add fields to basic structure of facturasprov table.
+        - excluir347: indicates if the document should be excluded from 347.
+-->
+<table>
+    <column>
+        <name>excluir347</name>
+        <type>boolean</type>
+        <default>false</default>
+    </column>
+</table>

--- a/Init.php
+++ b/Init.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of Modelo347 plugin for FacturaScripts
+ * Copyright (C) 2020-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace FacturaScripts\Plugins\Modelo347;
+
+use FacturaScripts\Core\Base\AjaxForms\PurchasesHeaderHTML;
+use FacturaScripts\Core\Base\AjaxForms\SalesHeaderHTML;
+use FacturaScripts\Core\Base\InitClass;
+
+/**
+ * Description of Init
+ *
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
+ */
+class Init extends InitClass
+{
+
+    public function init()
+    {
+        PurchasesHeaderHTML::addMod(new Mod\PurchasesHeaderHTMLMod());
+        SalesHeaderHTML::addMod(new Mod\SalesHeaderHTMLMod());
+    }
+
+    public function update()
+    {
+    }
+}

--- a/Mod/PurchasesHeaderHTMLMod.php
+++ b/Mod/PurchasesHeaderHTMLMod.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * This file is part of Modelo347 plugin for FacturaScripts
+ * Copyright (C) 2020-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace FacturaScripts\Plugins\Modelo347\Mod;
+
+use FacturaScripts\Core\Base\Contract\PurchasesModInterface;
+use FacturaScripts\Core\Base\Translator;
+use FacturaScripts\Core\Model\Base\PurchaseDocument;
+use FacturaScripts\Core\Model\User;
+
+/**
+ * Add new fields in the modal window of the document header
+ *   - excluir347: Allows the user to mark the invoice as excluded from the 347 calculation.
+ *
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
+ */
+class PurchasesHeaderHTMLMod implements PurchasesModInterface
+{
+
+    public function apply(PurchaseDocument &$model, array $formData, User $user)
+    {
+        if (property_exists($model, 'excluir347')) {
+            $model->excluir347 = ($formData['excluir347'] === 'true') ? true : false;
+        }
+    }
+
+    public function applyBefore(PurchaseDocument &$model, array $formData, User $user)
+    {
+    }
+
+    public function assets(): void
+    {
+    }
+
+    public function newFields(): array
+    {
+        return ['excluir347'];
+    }
+
+    public function renderField(Translator $i18n, PurchaseDocument $model, string $field): ?string
+    {
+        if ($field == 'excluir347') {
+            return $this->excluir347($i18n, $model);
+        }
+
+        return null;
+    }
+
+    private static function excluir347(Translator $i18n, PurchaseDocument $model): string
+    {
+        if (false === property_exists($model, 'excluir347')) {
+            return '';
+        }
+
+        $options = [];
+        foreach (['false', 'true'] as $row) {
+            $txt = ($row === 'true') ? 'yes' : 'no';
+            $options[] = ($row == $model->excluir347) ?
+                '<option value="' . $row . '" selected>' . $i18n->trans($txt) . '</option>' :
+                '<option value="' . $row . '">' . $i18n->trans($txt) . '</option>';
+        }
+
+        $attributes = $model->editable ? 'name="excluir347" required=""' : 'disabled=""';
+        return '<div class="col-sm-6">'
+            . '<div class="form-group">' . $i18n->trans('exclude-347')
+            . '<select ' . $attributes . ' class="form-control"/>'
+            . implode('', $options)
+            . '</select>'
+            . '</div>'
+            . '</div>';
+    }
+}

--- a/Mod/SalesHeaderHTMLMod.php
+++ b/Mod/SalesHeaderHTMLMod.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * This file is part of Modelo347 plugin for FacturaScripts
+ * Copyright (C) 2020-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace FacturaScripts\Plugins\Modelo347\Mod;
+
+use FacturaScripts\Core\Base\Contract\SalesModInterface;
+use FacturaScripts\Core\Base\Translator;
+use FacturaScripts\Core\Model\Base\SalesDocument;
+use FacturaScripts\Core\Model\User;
+
+/**
+ * Add new fields in the modal window of the document header
+ *   - excluir347: Allows the user to mark the invoice as excluded from the 347 calculation.
+ *
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
+ */
+class SalesHeaderHTMLMod implements SalesModInterface
+{
+
+    public function apply(SalesDocument &$model, array $formData, User $user)
+    {
+        if (property_exists($model, 'excluir347')) {
+            $model->excluir347 = ($formData['excluir347'] === 'true') ? true : false;
+        }
+    }
+
+    public function applyBefore(SalesDocument &$model, array $formData, User $user)
+    {
+    }
+
+    public function assets(): void
+    {
+    }
+
+    public function newFields(): array
+    {
+        return ['excluir347'];
+    }
+
+    public function renderField(Translator $i18n, SalesDocument $model, string $field): ?string
+    {
+        if ($field == 'excluir347') {
+            return $this->excluir347($i18n, $model);
+        }
+
+        return null;
+    }
+
+    private static function excluir347(Translator $i18n, SalesDocument $model): string
+    {
+        if (false === property_exists($model, 'excluir347')) {
+            return '';
+        }
+
+        $options = [];
+        foreach (['false', 'true'] as $row) {
+            $txt = ($row === 'true') ? 'yes' : 'no';
+            $options[] = ($row == $model->excluir347) ?
+                '<option value="' . $row . '" selected>' . $i18n->trans($txt) . '</option>' :
+                '<option value="' . $row . '">' . $i18n->trans($txt) . '</option>';
+        }
+
+        $attributes = $model->editable ? 'name="excluir347" required=""' : 'disabled=""';
+        return '<div class="col-sm-6">'
+            . '<div class="form-group">' . $i18n->trans('exclude-347')
+            . '<select ' . $attributes . ' class="form-control"/>'
+            . implode('', $options)
+            . '</select>'
+            . '</div>'
+            . '</div>';
+    }
+}

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -8,5 +8,6 @@
     "exclude-irpf": "Excluir IRPF",
     "model-347": "Modelo 347",
     "model-347-p": "El Modelo 347 es una declaración anual informativa de operaciones con terceras personas. Los empresarios y profesionales están obligados a la presentación del Modelo 347 siempre que hayan realizado operaciones con terceros por importe superior a 3.005,06 € durante el año natural (se puede cambiar la cantidad), computando de forma separada las entregas y las adquisiciones de bienes y servicios.",
-    "txt-for-treasury": "TXT para hacienda"
+    "txt-for-treasury": "TXT para hacienda",
+    "exclude-347": "Excluir del 347"
 }


### PR DESCRIPTION
Añadido nuevo campo en la cabecera de facturas de clientes y proveedores que permite indicar si el documento queda excluido en el cálculo del informe 347.

Se ha añadido una traducción al archivo es_ES, pero debería añadirse a todos los otros lenguajes.