### PR TITLE
Tarea 3178 - Corrección en la conversión de float a integer

### DIFF
--- a/Lib/Txt347Export.php
+++ b/Lib/Txt347Export.php
@@ -174,7 +174,7 @@ class Txt347Export
 
     protected static function getDecimal($number): int
     {
-        return ((float)$number - (int)$number) * 100;
+        return (int)((float)$number - (int)$number) * 100;
     }
 
     protected static function loadExercise(string $codejercicio): void

--- a/Lib/Txt347Export.php
+++ b/Lib/Txt347Export.php
@@ -137,28 +137,28 @@ class Txt347Export
                 . self::getProvincia($item['provincia']) . self::getPais($item['codpais']) // CÓDIGO PROVINCIA/PAIS
                 . ' ' // BLANCOS
                 . 'B' // CLAVE OPERACIÓN
-                . ($item['total'] < 0 ? 'N' : ' ')
+                . ($item['total'] < 0.00 ? 'N' : ' ')
                 . self::formatString((int)$item['total'], 13, '0', STR_PAD_LEFT)
                 . self::formatString(self::getDecimal($item['total']), 2, '0', STR_PAD_LEFT) // IMPORTE ANUAL DE LAS OPERACIONES
                 . ' ' // OPERACIÓN SEGURO
                 . ' ' // ARRENDAMIENTO LOCAL NEGOCIO
                 . self::formatString('', 15, '0', STR_PAD_RIGHT) // IMPORTE PERCIBIDO EN METÁLICO
-                . ($item['total'] < 0 ? 'N' : ' ')
+                . ($item['total'] < 0.00 ? 'N' : ' ')
                 . self::formatString('', 15, '0', STR_PAD_LEFT) // IMPORTE ANUAL PERCIBIDO POR TRANSMISIONES DE INMUEBLES SUJETAS A IVA
                 . self::formatString('', 4, '0', STR_PAD_RIGHT) // EJERCICIO
-                . ($item['t1'] < 0 ? 'N' : ' ')
+                . ($item['t1'] < 0.00 ? 'N' : ' ')
                 . self::formatString((int)$item['t1'], 13, '0', STR_PAD_LEFT)
                 . self::formatString(self::getDecimal($item['t1']), 2, '0', STR_PAD_LEFT) // IMPORTE DE LAS OPERACIONES PRIMER TRIMESTRE
                 . ' ' . self::formatString('', 15, '0', STR_PAD_LEFT) // IMPORTE PERCIBIDO POR TRANSMISIONES DE INMUEBLES SUJETAS A IVA PRIMER TRIMESTRE
-                . ($item['t2'] < 0 ? 'N' : ' ')
+                . ($item['t2'] < 0.00 ? 'N' : ' ')
                 . self::formatString((int)$item['t2'], 13, '0', STR_PAD_LEFT)
                 . self::formatString(self::getDecimal($item['t2']), 2, '0', STR_PAD_LEFT) // IMPORTE DE LAS OPERACIONES SEGUNDO TRIMESTRE
                 . ' ' . self::formatString('', 15, '0', STR_PAD_LEFT) // IMPORTE PERCIBIDO POR TRANSMISIONES DE INMUEBLES SUJETAS A IVA SEGUNDO TRIMESTRE
-                . ($item['t3'] < 0 ? 'N' : ' ')
+                . ($item['t3'] < 0.00 ? 'N' : ' ')
                 . self::formatString((int)$item['t3'], 13, '0', STR_PAD_LEFT)
                 . self::formatString(self::getDecimal($item['t3']), 2, '0', STR_PAD_LEFT) // IMPORTE DE LAS OPERACIONES TERCER TRIMESTRE
                 . ' ' . self::formatString('', 15, '0', STR_PAD_LEFT) // IMPORTE PERCIBIDO POR TRANSMISIONES DE INMUEBLES SUJETAS A IVA TERCER TRIMESTRE
-                . ($item['t4'] < 0 ? 'N' : ' ')
+                . ($item['t4'] < 0.00 ? 'N' : ' ')
                 . self::formatString((int)$item['t4'], 13, '0', STR_PAD_LEFT)
                 . self::formatString(self::getDecimal($item['t4']), 2, '0', STR_PAD_LEFT) // IMPORTE DE LAS OPERACIONES CUARTO TRIMESTRE
                 . ' ' . self::formatString('', 15, '0', STR_PAD_LEFT) // IMPORTE PERCIBIDO POR TRANSMISIONES DE INMUEBLES SUJETAS A IVA CUARTO TRIMESTRE
@@ -396,28 +396,28 @@ class Txt347Export
                 . self::getProvincia($item['provincia']) . self::getPais($item['codpais']) // CÓDIGO PROVINCIA/PAIS
                 . ' ' // BLANCOS
                 . 'A' // CLAVE OPERACIÓN
-                . ($item['total'] < 0 ? 'N' : ' ')
+                . ($item['total'] < 0.00 ? 'N' : ' ')
                 . self::formatString((int)$item['total'], 13, '0', STR_PAD_LEFT)
                 . self::formatString(self::getDecimal($item['total']), 2, '0', STR_PAD_LEFT) // IMPORTE ANUAL DE LAS OPERACIONES
                 . ' ' // OPERACIÓN SEGURO
                 . ' ' // ARRENDAMIENTO LOCAL NEGOCIO
                 . self::formatString('', 15, '0', STR_PAD_RIGHT) // IMPORTE PERCIBIDO EN METÁLICO
-                . ($item['total'] < 0 ? 'N' : ' ')
+                . ($item['total'] < 0.00 ? 'N' : ' ')
                 . self::formatString('', 15, '0', STR_PAD_LEFT) // IMPORTE ANUAL PERCIBIDO POR TRANSMISIONES DE INMUEBLES SUJETAS A IVA
                 . self::formatString('', 4, '0', STR_PAD_RIGHT) // EJERCICIO
-                . ($item['t1'] < 0 ? 'N' : ' ')
+                . ($item['t1'] < 0.00 ? 'N' : ' ')
                 . self::formatString((int)$item['t1'], 13, '0', STR_PAD_LEFT)
                 . self::formatString(self::getDecimal($item['t1']), 2, '0', STR_PAD_LEFT) // IMPORTE DE LAS OPERACIONES PRIMER TRIMESTRE
                 . ' ' . self::formatString('', 15, '0', STR_PAD_LEFT) // IMPORTE PERCIBIDO POR TRANSMISIONES DE INMUEBLES SUJETAS A IVA PRIMER TRIMESTRE
-                . ($item['t2'] < 0 ? 'N' : ' ')
+                . ($item['t2'] < 0.00 ? 'N' : ' ')
                 . self::formatString((int)$item['t2'], 13, '0', STR_PAD_LEFT)
                 . self::formatString(self::getDecimal($item['t2']), 2, '0', STR_PAD_LEFT) // IMPORTE DE LAS OPERACIONES SEGUNDO TRIMESTRE
                 . ' ' . self::formatString('', 15, '0', STR_PAD_LEFT) // IMPORTE PERCIBIDO POR TRANSMISIONES DE INMUEBLES SUJETAS A IVA SEGUNDO TRIMESTRE
-                . ($item['t3'] < 0 ? 'N' : ' ')
+                . ($item['t3'] < 0.00 ? 'N' : ' ')
                 . self::formatString((int)$item['t3'], 13, '0', STR_PAD_LEFT)
                 . self::formatString(self::getDecimal($item['t3']), 2, '0', STR_PAD_LEFT) // IMPORTE DE LAS OPERACIONES TERCER TRIMESTRE
                 . ' ' . self::formatString('', 15, '0', STR_PAD_LEFT) // IMPORTE PERCIBIDO POR TRANSMISIONES DE INMUEBLES SUJETAS A IVA TERCER TRIMESTRE
-                . ($item['t4'] < 0 ? 'N' : ' ')
+                . ($item['t4'] < 0.00 ? 'N' : ' ')
                 . self::formatString((int)$item['t4'], 13, '0', STR_PAD_LEFT)
                 . self::formatString(self::getDecimal($item['t4']), 2, '0', STR_PAD_LEFT) // IMPORTE DE LAS OPERACIONES CUARTO TRIMESTRE
                 . ' ' . self::formatString('', 15, '0', STR_PAD_LEFT) // IMPORTE PERCIBIDO POR TRANSMISIONES DE INMUEBLES SUJETAS A IVA CUARTO TRIMESTRE


### PR DESCRIPTION
Se han añadido el cast en la conversión de valores float a integer para evitar el warning de PHP a partir de la versión 8.1